### PR TITLE
Fix compile error on Mac Clang 12.0.5

### DIFF
--- a/Foundation/include/Poco/RecursiveDirectoryIteratorImpl.h
+++ b/Foundation/include/Poco/RecursiveDirectoryIteratorImpl.h
@@ -41,7 +41,7 @@ public:
 	};
 
 	RecursiveDirectoryIteratorImpl(const std::string& path, UInt16 maxDepth = D_INFINITE)
-		: _maxDepth(maxDepth), _traverseStrategy(std::ptr_fun(depthFun), _maxDepth), _isFinished(false), _rc(1)
+		: _maxDepth(maxDepth), _traverseStrategy(depthFun, _maxDepth), _isFinished(false), _rc(1)
 	{
 		_itStack.push(DirectoryIterator(path));
 		_current = _itStack.top()->path();


### PR DESCRIPTION
`std::ptr_func` was deprecated/removed since C++11/17. Seems like Mac Clang finally removes it from 12.0.5.