### PR TITLE
Port to using boringssl

### DIFF
--- a/Crypto/include/Poco/Crypto/CipherKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/CipherKeyImpl.h
@@ -48,7 +48,10 @@ public:
 		MODE_ECB,			/// Electronic codebook (plain concatenation)
 		MODE_CBC,			/// Cipher block chaining (default)
 		MODE_CFB,			/// Cipher feedback
-		MODE_OFB			/// Output feedback
+		MODE_OFB,			/// Output feedback
+		MODE_CTR,           /// Counter mode
+		MODE_GCM,           /// Galois/Counter mode
+		MODE_CCM            /// Counter with CBC-MAC
 	};
 
 	CipherKeyImpl(const std::string& name,
@@ -62,8 +65,7 @@ public:
 
 	CipherKeyImpl(const std::string& name,
 		const ByteVec& key,
-		const ByteVec& iv
-	);
+		const ByteVec& iv);
 		/// Creates a new CipherKeyImpl object, using the
 		/// given cipher name, key and initialization vector.
 
@@ -88,7 +90,7 @@ public:
 
 	Mode mode() const;
 		/// Returns the Cipher's mode of operation.
-	
+
 	const ByteVec& getKey() const;
 		/// Returns the key for the Cipher.
 
@@ -103,7 +105,7 @@ public:
 
 	const EVP_CIPHER* cipher();
 		/// Returns the cipher object
-	
+
 private:
 	void generateKey(const std::string& passphrase,
 		const std::string& salt,

--- a/Crypto/include/Poco/Crypto/DigestEngine.h
+++ b/Crypto/include/Poco/Crypto/DigestEngine.h
@@ -39,13 +39,13 @@ public:
 		/// See the OpenSSL documentation for a list of supported digest algorithms.
 		///
 		/// Throws a Poco::NotFoundException if no algorithm with the given name exists.
-		
+
 	~DigestEngine();
 		/// Destroys the DigestEngine.
-	
+
 	const std::string& algorithm() const;
 		/// Returns the name of the digest algorithm.
-	
+
 	int nid() const;
 		/// Returns the NID (OpenSSL object identifier) of the digest algorithm.
 
@@ -56,7 +56,7 @@ public:
 
 protected:
 	void updateImpl(const void* data, std::size_t length);
-	
+
 private:
 	std::string _name;
 	EVP_MD_CTX* _pContext;

--- a/Crypto/include/Poco/Crypto/PKCS12Container.h
+++ b/Crypto/include/Poco/Crypto/PKCS12Container.h
@@ -86,7 +86,7 @@ public:
 
 private:
 	void load(PKCS12* pPKCS12, const std::string& password = "");
-	std::string extractFriendlyName(X509* pCert);
+//	std::string extractFriendlyName(X509* pCert);
 
 	typedef std::unique_ptr<X509Certificate> CertPtr;
 

--- a/Crypto/include/Poco/Crypto/X509Certificate.h
+++ b/Crypto/include/Poco/Crypto/X509Certificate.h
@@ -51,7 +51,7 @@ public:
 		NID_PKCS9_EMAIL_ADDRESS = 48,
 		NID_SERIAL_NUMBER = 105
 	};
-	
+
 	explicit X509Certificate(std::istream& istr);
 		/// Creates the X509Certificate object by reading
 		/// a certificate in PEM format from a stream.
@@ -92,12 +92,12 @@ public:
 
 	const std::string& issuerName() const;
 		/// Returns the certificate issuer's distinguished name.
-		
+
 	std::string issuerName(NID nid) const;
 		/// Extracts the information specified by the given
 		/// NID (name identifier) from the certificate issuer's
 		/// distinguished name.
-		
+
 	const std::string& subjectName() const;
 		/// Returns the certificate subject's distinguished name.
 
@@ -105,21 +105,21 @@ public:
 		/// Extracts the information specified by the given
 		/// NID (name identifier) from the certificate subject's
 		/// distinguished name.
-		
+
 	std::string commonName() const;
 		/// Returns the common name stored in the certificate
 		/// subject's distinguished name.
-		
+
 	void extractNames(std::string& commonName, std::set<std::string>& domainNames) const;
 		/// Extracts the common name and the alias domain names from the
 		/// certificate.
-		
+
 	Poco::DateTime validFrom() const;
 		/// Returns the date and time the certificate is valid from.
-		
+
 	Poco::DateTime expiresOn() const;
 		/// Returns the date and time the certificate expires.
-		
+
 	void save(std::ostream& stream) const;
 		/// Writes the certificate to the given stream.
 		/// The certificate is written in PEM format.
@@ -127,7 +127,7 @@ public:
 	void save(const std::string& path) const;
 		/// Writes the certificate to the file given by path.
 		/// The certificate is written in PEM format.
-		
+
 	bool issuedBy(const X509Certificate& issuerCertificate) const;
 		/// Checks whether the certificate has been issued by
 		/// the issuer given by issuerCertificate. This can be
@@ -151,6 +151,11 @@ public:
 	const X509* certificate() const;
 		/// Returns the underlying OpenSSL certificate.
 
+	X509* dup() const;
+		/// Duplicates and returns the underlying OpenSSL certificate. Note that
+		/// the caller assumes responsibility for the lifecycle of the created
+		/// certificate.
+
 	std::string signatureAlgorithm() const;
 		/// Returns the certificate signature algorithm long name.
 
@@ -171,20 +176,20 @@ protected:
 	void load(std::istream& stream);
 		/// Loads the certificate from the given stream. The
 		/// certificate must be in PEM format.
-		
+
 	void load(const std::string& path);
 		/// Loads the certificate from the given file. The
 		/// certificate must be in PEM format.
 
 	void init();
 		/// Extracts issuer and subject name from the certificate.
-	
+
 private:
 	enum
 	{
 		NAME_BUFFER_SIZE = 256
 	};
-	
+
 	std::string _issuerName;
 	std::string _subjectName;
 	std::string _serialNumber;
@@ -226,6 +231,12 @@ inline const std::string& X509Certificate::subjectName() const
 inline const X509* X509Certificate::certificate() const
 {
 	return _pCert;
+}
+
+
+inline X509* X509Certificate::dup() const
+{
+	return X509_dup(_pCert);
 }
 
 

--- a/Crypto/src/CipherKeyImpl.cpp
+++ b/Crypto/src/CipherKeyImpl.cpp
@@ -56,11 +56,12 @@ CipherKeyImpl::CipherKeyImpl(const std::string& name,
 
 CipherKeyImpl::CipherKeyImpl(const std::string& name,
 	const ByteVec& key,
-	const ByteVec& iv): _pCipher(0),
-		_pDigest(0),
-		_name(name),
-		_key(key),
-		_iv(iv)
+	const ByteVec& iv):
+	_pCipher(0),
+	_pDigest(0),
+	_name(name),
+	_key(key),
+	_iv(iv)
 {
 	// dummy access to Cipherfactory so that the EVP lib is initilaized
 	CipherFactory::defaultFactory();
@@ -70,8 +71,9 @@ CipherKeyImpl::CipherKeyImpl(const std::string& name,
 		throw Poco::NotFoundException("Cipher " + name + " was not found");
 }
 
-	
-CipherKeyImpl::CipherKeyImpl(const std::string& name): _pCipher(0),
+
+CipherKeyImpl::CipherKeyImpl(const std::string& name):
+	_pCipher(0),
 	_pDigest(0),
 	_name(name),
 	_key(),
@@ -132,7 +134,7 @@ void CipherKeyImpl::generateKey()
 
 	getRandomBytes(vec, keySize());
 	setKey(vec);
-	
+
 	getRandomBytes(vec, ivSize());
 	setIV(vec);
 }
@@ -141,7 +143,7 @@ void CipherKeyImpl::generateKey()
 void CipherKeyImpl::getRandomBytes(ByteVec& vec, std::size_t count)
 {
 	Poco::RandomInputStream random;
-	
+
 	vec.clear();
 	vec.reserve(count);
 

--- a/Crypto/src/CipherKeyImpl.cpp
+++ b/Crypto/src/CipherKeyImpl.cpp
@@ -112,6 +112,15 @@ CipherKeyImpl::Mode CipherKeyImpl::mode() const
 
 	case EVP_CIPH_OFB_MODE:
 		return MODE_OFB;
+
+#if OPENSSL_VERSION_NUMBER >= 0x10001000L
+	case EVP_CIPH_CTR_MODE:
+		return MODE_CTR;
+
+	case EVP_CIPH_GCM_MODE:
+		return MODE_GCM;
+
+#endif
 	}
 	throw Poco::IllegalStateException("Unexpected value of EVP_CIPHER_mode()");
 }

--- a/Crypto/src/DigestEngine.cpp
+++ b/Crypto/src/DigestEngine.cpp
@@ -25,11 +25,13 @@ DigestEngine::DigestEngine(const std::string& name):
 	_pContext(EVP_MD_CTX_create())
 {
 	const EVP_MD* md = EVP_get_digestbyname(_name.c_str());
-	if (!md) throw OpenSSLException(_name);
-	EVP_DigestInit_ex(_pContext, md, NULL);	
+	// if (!md) throw OpenSSLException(_name);
+	// EVP_DigestInit_ex(_pContext, md, NULL);	
+	if (!md) throw Poco::NotFoundException(_name);
+	EVP_DigestInit_ex(_pContext, md, NULL);
 }
 
-	
+
 DigestEngine::~DigestEngine()
 {
 	EVP_MD_CTX_destroy(_pContext);
@@ -37,7 +39,7 @@ DigestEngine::~DigestEngine()
 
 int DigestEngine::nid() const
 {
-	return EVP_MD_nid(EVP_MD_CTX_md(_pContext));
+	return EVP_MD_type(EVP_MD_CTX_md(_pContext));
 }
 
 std::size_t DigestEngine::digestLength() const

--- a/Crypto/src/DigestEngine.cpp
+++ b/Crypto/src/DigestEngine.cpp
@@ -25,8 +25,6 @@ DigestEngine::DigestEngine(const std::string& name):
 	_pContext(EVP_MD_CTX_create())
 {
 	const EVP_MD* md = EVP_get_digestbyname(_name.c_str());
-	// if (!md) throw OpenSSLException(_name);
-	// EVP_DigestInit_ex(_pContext, md, NULL);	
 	if (!md) throw Poco::NotFoundException(_name);
 	EVP_DigestInit_ex(_pContext, md, NULL);
 }

--- a/Crypto/src/OpenSSLInitializer.cpp
+++ b/Crypto/src/OpenSSLInitializer.cpp
@@ -63,7 +63,7 @@ void OpenSSLInitializer::initialize()
 	if (++_rc == 1)
 	{
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-		CONF_modules_load(NULL, NULL, 0);
+		CONF_modules_load_file(NULL, NULL, 0);
 #elif OPENSSL_VERSION_NUMBER >= 0x0907000L
 		OPENSSL_config(NULL);
 #endif

--- a/Crypto/src/PKCS12Container.cpp
+++ b/Crypto/src/PKCS12Container.cpp
@@ -120,7 +120,7 @@ PKCS12Container::~PKCS12Container()
 }
 
 
-std::string PKCS12Container::extractFriendlyName(X509* pCert)
+/*std::string PKCS12Container::extractFriendlyName(X509* pCert)
 {
 	std::string friendlyName;
 	if(pCert)
@@ -142,7 +142,7 @@ std::string PKCS12Container::extractFriendlyName(X509* pCert)
 	else throw NullPointerException("PKCS12Container::extractFriendlyName()");
 
 	return friendlyName;
-}
+}*/
 
 
 void PKCS12Container::load(PKCS12* pPKCS12, const std::string& password)
@@ -156,7 +156,7 @@ void PKCS12Container::load(PKCS12* pPKCS12, const std::string& password)
 			if (pCert)
 			{
 				_pX509Cert.reset(new X509Certificate(pCert, true));
-				_pkcsFriendlyName = extractFriendlyName(pCert);
+				//_pkcsFriendlyName = extractFriendlyName(pCert);
 			}
 			else _pX509Cert.reset();
 
@@ -171,7 +171,7 @@ void PKCS12Container::load(PKCS12* pPKCS12, const std::string& password)
 					if (pX509)
 					{
 						_caCertList.push_back(X509Certificate(pX509, true));
-						_caCertNames.push_back(extractFriendlyName(pX509));
+						//_caCertNames.push_back(extractFriendlyName(pX509));
 					}
 					else throw OpenSSLException("PKCS12Container::load()");
 				}

--- a/Crypto/src/RSACipherImpl.cpp
+++ b/Crypto/src/RSACipherImpl.cpp
@@ -50,8 +50,6 @@ namespace
 			return RSA_PKCS1_PADDING;
 		case RSA_PADDING_PKCS1_OAEP:
 			return RSA_PKCS1_OAEP_PADDING;
-		case RSA_PADDING_SSLV23:
-			return RSA_SSLV23_PADDING;
 		case RSA_PADDING_NONE:
 			return RSA_NO_PADDING;
 		default:

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -198,9 +198,11 @@ void Context::useCertificate(const Poco::Crypto::X509Certificate& certificate)
 	
 void Context::addChainCertificate(const Poco::Crypto::X509Certificate& certificate)
 {
-	int errCode = SSL_CTX_add_extra_chain_cert(_pSSLContext, certificate.certificate());
+	X509* pCert = certificate.dup();
+	int errCode = SSL_CTX_add_extra_chain_cert(_pSSLContext, pCert);
 	if (errCode != 1)
 	{
+		X509_free(pCert);
 		std::string msg = Utility::getLastError();
 		throw SSLContextException("Cannot add chain certificate to Context", msg);
 	}


### PR DESCRIPTION
TiFlash is bundling boringssl, this PR adapts this movement: https://github.com/pingcap/tics/pull/3987

It cherry-picks the following upstream changes:
* https://github.com/ClickHouse-Extras/poco/commit/68f46e2b16f2f4be7aef371117f72488ded40f00
* https://github.com/ClickHouse-Extras/poco/commit/adc2cad7b48b19a1242efa4099067ffdd80e8c29
* https://github.com/ClickHouse-Extras/poco/commit/e19f33351ddd630351f391a37ad98a5d03519bed

Plus minor fixes to our own code.