### PR TITLE
Avoid thread_local pollution

### DIFF
--- a/Foundation/include/Poco/Thread_STD.h
+++ b/Foundation/include/Poco/Thread_STD.h
@@ -30,13 +30,6 @@
 #include <thread>
 
 
-#ifdef __APPLE__
-#define thread_local __thread
-#elif defined(_MSC_VER)
-#include "Poco/UnWindows.h"
-#endif
-
-
 namespace Poco {
 
 


### PR DESCRIPTION
In AppleClang C++11 thread_local is already supported.